### PR TITLE
django 1.9 fix

### DIFF
--- a/fieldobjectpermissions/apps.py
+++ b/fieldobjectpermissions/apps.py
@@ -132,7 +132,6 @@ class FieldObjectPermissionsConfig(AppConfig):
     verbose_name = 'Field Object Permissions'
 
     def ready(self):
-        # from .backends import GROUP_FIELDS, OWNER_FIELDS, GROUP_ACTIONS, OWNER_ACTIONS
         post_migrate.connect(
             create_permissions,
             dispatch_uid='fieldobjectpermissions.create_permissions',

--- a/fieldobjectpermissions/apps.py
+++ b/fieldobjectpermissions/apps.py
@@ -5,12 +5,11 @@ from django.db import DEFAULT_DB_ALIAS, router
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.signals import post_migrate
 
-from .backends import GROUP_FIELDS, OWNER_FIELDS, GROUP_ACTIONS, OWNER_ACTIONS
-
 
 def _get_extra_permissions(opts, ctype):
     new_perms = []
 
+    from .backends import GROUP_FIELDS, OWNER_FIELDS, GROUP_ACTIONS, OWNER_ACTIONS
     for field in GROUP_FIELDS:
         try:
             opts.get_field(field)
@@ -133,6 +132,7 @@ class FieldObjectPermissionsConfig(AppConfig):
     verbose_name = 'Field Object Permissions'
 
     def ready(self):
+        # from .backends import GROUP_FIELDS, OWNER_FIELDS, GROUP_ACTIONS, OWNER_ACTIONS
         post_migrate.connect(
             create_permissions,
             dispatch_uid='fieldobjectpermissions.create_permissions',


### PR DESCRIPTION
Stopped working in Django 1.9 +

Was getting the error:
```
...
File "/usr/local/var/pyenv/versions/3.4.3/envs/blah/lib/python3.4/site-packages/django/apps/registry.py", line 124, in check_apps_ready
    raise AppRegistryNotReady("Apps aren't loaded yet.")
```

Django 1.9 removed the ability to import models before an app is "loaded".  [[1]](https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9)
>All models need to be defined inside an installed application or declare an explicit app_label.  Furthermore, it isn’t possible to import them before their application is loaded. In particular, it isn’t possible to import models inside the root package of an application.

Django 1.10 docs suggest moving the import statements into `def ready(self)` [[2]](https://docs.djangoproject.com/en/1.10/ref/applications/#django.apps.AppConfig.ready)
>Although you can’t import models at the module-level where AppConfig classes are defined, you can import them in ready(), using either an import statement or get_model().

Moved the imports to the function that was used in `ready(self)`